### PR TITLE
fix: Remove quotes from listener port

### DIFF
--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -3,7 +3,7 @@ Description=Node Exporter
 
 [Service]
 User=root
-ExecStart={{ node_exporter_final_dest }}/node_exporter --web.listen-address=":{{ node_exporter_listen_port }}"
+ExecStart={{ node_exporter_final_dest }}/node_exporter --web.listen-address=:{{ node_exporter_listen_port }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### Description

No need for quotes here. Adding quotes will cause the service to fail to start.